### PR TITLE
Fix #80

### DIFF
--- a/E.Deezer.Tests/Properties/AssemblyInfo.cs
+++ b/E.Deezer.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.180")]
-[assembly: AssemblyFileVersion("1.0.0.180")]
+[assembly: AssemblyVersion("1.0.0.182")]
+[assembly: AssemblyFileVersion("1.0.0.182")]

--- a/E.Deezer/Api/Internal/DeezerCreateResponse.cs
+++ b/E.Deezer/Api/Internal/DeezerCreateResponse.cs
@@ -11,6 +11,6 @@ namespace E.Deezer.Api
     internal class DeezerCreateResponse
     {
         [JsonProperty(PropertyName = "id")]
-        public uint Id { get; set; }
+        public ulong Id { get; set; }
     }
 }

--- a/E.Deezer/Api/User.cs
+++ b/E.Deezer/Api/User.cs
@@ -56,7 +56,7 @@ namespace E.Deezer.Api
 
         Task<IEnumerable<IRadio>> GetRecommendedRadio(uint aStart = 0, uint aCount = 100);
 
-        Task<uint> CreatePlaylist(string title);
+        Task<ulong> CreatePlaylist(string title);
 
         Task<bool> AddRadioToFavourite(IRadio aRadio);
         Task<bool> AddRadioToFavourite(ulong radioId);
@@ -167,7 +167,7 @@ namespace E.Deezer.Api
             => Get<Radio, IRadio>("recommendations/radios", DeezerPermissions.BasicAccess, aStart, aCount);
 
 
-        public Task<uint> CreatePlaylist(string title)
+        public Task<ulong> CreatePlaylist(string title)
         {
             List<IRequestParameter> parms = new List<IRequestParameter>()
             {


### PR DESCRIPTION
Report of some returned id values fail to parse. 

Id valuew was outside the values allowed in an `uint`. Use `ulong` instead. 